### PR TITLE
Remove trailing commas from function calls

### DIFF
--- a/src/Collectors/ChangeSetCollector.php
+++ b/src/Collectors/ChangeSetCollector.php
@@ -102,7 +102,7 @@ class ChangeSetCollector extends AbstractCollector
                 $mainTable,
                 $itemTable,
                 $relationTable,
-            ],
+            ]
         );
 
         $query->addLeftJoin($itemTableRaw, sprintf('%s."ID" = %s."ChangeSetID"', $mainTable, $itemTable));

--- a/src/Collectors/VersionedCollector.php
+++ b/src/Collectors/VersionedCollector.php
@@ -388,7 +388,7 @@ class VersionedCollector extends AbstractCollector
                 $baseTable . '."RecordID"' => $recordId,
                 sprintf($baseTable . '."Version" IN (%s)', DB::placeholders($versions)) => $versions,
             ],
-            $baseTables,
+            $baseTables
         );
 
         // Join additional tables so we can delete all related data (avoid orphaned version data)


### PR DESCRIPTION
Remove trailing commas from function calls for compatibility with PHP versions below 7.3