### PR TITLE
Remove more trailing commas from function calls

### DIFF
--- a/src/Collectors/VersionedCollector.php
+++ b/src/Collectors/VersionedCollector.php
@@ -209,7 +209,7 @@ class VersionedCollector extends AbstractCollector
                     // on predicate
                     $baseTable . '."RecordID" = "MaxVersionSelect"."RecordID"',
                     // table alias
-                    'MaxVersionSelect',
+                    'MaxVersionSelect'
                 );
                 $query->addWhere($baseTable . '."Version" < "MaxVersionSelect"."MaxPublishedVersion"');
             }
@@ -309,7 +309,7 @@ class VersionedCollector extends AbstractCollector
                         // on predicate
                         $baseTable . '."RecordID" = "MaxVersionSelect"."RecordID"',
                         // table alias
-                        'MaxVersionSelect',
+                        'MaxVersionSelect'
                     );
                     $query->addWhere($baseTable . '."Version" < "MaxVersionSelect"."MaxPublishedVersion"');
                 }


### PR DESCRIPTION
Sorry, missed a few trailing commas when rebasing.