### PR TITLE
Add class checks to make collector job and its test truly optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "symbiote/silverstripe-queuedjobs": "^4.7"
     },
     "suggest": {
-        "silverstripe/queuedjobs": "For usage of the GarbageCollectorJob within your application"
+        "symbiote/silverstripe-queuedjobs": "For usage of the GarbageCollectorJob within your application"
     },
     "scripts": {
         "test": "vendor/bin/phpunit"

--- a/src/Jobs/GarbageCollectorJob.php
+++ b/src/Jobs/GarbageCollectorJob.php
@@ -8,6 +8,10 @@ use SilverStripe\GarbageCollector\GarbageCollectorService;
 use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
 use Symbiote\QueuedJobs\Services\QueuedJob;
 
+if (!class_exists(AbstractQueuedJob::class)) {
+    return;
+}
+
 
 /**
  * @property array $versions

--- a/tests/php/Jobs/GarbageCollectorJobTest.php
+++ b/tests/php/Jobs/GarbageCollectorJobTest.php
@@ -7,6 +7,7 @@ use SilverStripe\GarbageCollector\CollectorInterface;
 use SilverStripe\GarbageCollector\Jobs\GarbageCollectorJob;
 use SilverStripe\GarbageCollector\Tests\Ship;
 use SilverStripe\GarbageCollector\Tests\MockProcessor;
+use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
 use Symbiote\QueuedJobs\Services\QueuedJob;
 
 class GarbageCollectorJobTest extends SapphireTest
@@ -22,6 +23,16 @@ class GarbageCollectorJobTest extends SapphireTest
     protected static $extra_dataobjects = [
         Ship::class,
     ];
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+
+        if (!class_exists(AbstractQueuedJob::class)) {
+            self::markTestSkipped('This test requires the queuedjobs module to be installed');
+        }
+    }
+
 
     public function testSetup()
     {


### PR DESCRIPTION
Adding class checks to make the job and the tests gracefully handle the queued module not being present.

Fix for #12 