### PR TITLE
Fix for MTI models

### DIFF
--- a/src/Collectors/VersionedCollector.php
+++ b/src/Collectors/VersionedCollector.php
@@ -444,7 +444,7 @@ class VersionedCollector extends AbstractCollector
      */
     public function getTableNameForClass(string $class): string
     {
-        $table = DataObject::getSchema()->baseDataTable($class);
+        $table = DataObject::getSchema()->tableName($class);
 
         // Fallback to class name if no table name is specified
         return $table ?: $class;

--- a/tests/php/CargoShip.php
+++ b/tests/php/CargoShip.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SilverStripe\GarbageCollector\Tests;
+
+use SilverStripe\Dev\TestOnly;
+
+class CargoShip extends Ship implements TestOnly
+{
+    /**
+     * @var string
+     */
+    private static $table_name = 'GarbageCollector_CargoShip';
+
+    /**
+     * @var string[]
+     */
+    private static $db = [
+        'Title' => 'Varchar',
+    ];
+}

--- a/tests/php/Collectors/ChangeSetCollectorTest.php
+++ b/tests/php/Collectors/ChangeSetCollectorTest.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\GarbageCollector\Tests\Collectors;
 
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\GarbageCollector\Tests\CargoShip;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\GarbageCollector\Collectors\ChangeSetCollector;
@@ -24,6 +25,7 @@ class ChangeSetCollectorTest extends SapphireTest
      */
     protected static $extra_dataobjects = [
         Ship::class,
+        CargoShip::class,
     ];
 
     /**

--- a/tests/php/Collectors/ObsoleteTableCollectorTest.php
+++ b/tests/php/Collectors/ObsoleteTableCollectorTest.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\GarbageCollector\Tests\Collectors;
 
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\GarbageCollector\Tests\CargoShip;
 use SilverStripe\ORM\DB;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Config\Collections\MutableConfigCollectionInterface;
@@ -21,6 +22,7 @@ class ObsoleteTableCollectorTest extends SapphireTest
      */
     protected static $extra_dataobjects = [
         Ship::class,
+        CargoShip::class,
     ];
 
     public function testGetName(): void

--- a/tests/php/Extensions/FluentVersionedCollectorExtensionTest.php
+++ b/tests/php/Extensions/FluentVersionedCollectorExtensionTest.php
@@ -4,6 +4,7 @@ namespace SilverStripe\GarbageCollector\Tests\Extensions;
 
 use SilverStripe\GarbageCollector\Collectors\VersionedCollector;
 use SilverStripe\GarbageCollector\Extensions\FluentVersionedCollectorExtension;
+use SilverStripe\GarbageCollector\Tests\CargoShip;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\Versioned\Versioned;
 use TractorCow\Fluent\Extension\FluentVersionedExtension;
@@ -28,6 +29,7 @@ class FluentVersionedCollectorExtensionTest extends VersionedCollectorTest
      */
     protected static $extra_dataobjects = [
         Ship::class,
+        CargoShip::class,
     ];
 
     /**
@@ -58,6 +60,7 @@ class FluentVersionedCollectorExtensionTest extends VersionedCollectorTest
      * @param ?int $deletion_limit
      * @param ?int $keep_limit
      * @param bool $keep_unpublished_drafts
+     * @param string $model_class
      * @throws ValidationException
      * @dataProvider collectionsProvider
      */
@@ -67,7 +70,8 @@ class FluentVersionedCollectorExtensionTest extends VersionedCollectorTest
         array $expected = [],
         int $deletion_limit = null,
         int $keep_limit = null,
-        bool $keep_unpublished_drafts = false
+        bool $keep_unpublished_drafts = false,
+        string $model_class = Ship::class
     ): void
     {
         FluentState::singleton()->withState(function (FluentState $state) use ($id, $modifyDate, $expected, $deletion_limit): void {

--- a/tests/php/GarbageCollectionServiceTest.php
+++ b/tests/php/GarbageCollectionServiceTest.php
@@ -21,6 +21,7 @@ class GarbageCollectorServiceTest extends SapphireTest
      */
     protected static $extra_dataobjects = [
         Ship::class,
+        CargoShip::class,
     ];
 
     private $service;

--- a/tests/php/Jobs/GarbageCollectorJobTest.php
+++ b/tests/php/Jobs/GarbageCollectorJobTest.php
@@ -5,6 +5,7 @@ namespace SilverStripe\GarbageCollector\Tests\Jobs;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\GarbageCollector\CollectorInterface;
 use SilverStripe\GarbageCollector\Jobs\GarbageCollectorJob;
+use SilverStripe\GarbageCollector\Tests\CargoShip;
 use SilverStripe\GarbageCollector\Tests\Ship;
 use SilverStripe\GarbageCollector\Tests\MockProcessor;
 use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
@@ -22,6 +23,7 @@ class GarbageCollectorJobTest extends SapphireTest
      */
     protected static $extra_dataobjects = [
         Ship::class,
+        CargoShip::class,
     ];
 
     public static function setUpBeforeClass()

--- a/tests/php/Models.yml
+++ b/tests/php/Models.yml
@@ -9,3 +9,7 @@ SilverStripe\GarbageCollector\Tests\Ship:
     Title: 'TestShip4'
   ship5:
     Title: 'TestShip5'
+
+SilverStripe\GarbageCollector\Tests\CargoShip:
+  cargoship1:
+    Title: 'TestCargoShip1'

--- a/tests/php/Processors/DataListProcessorTest.php
+++ b/tests/php/Processors/DataListProcessorTest.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\GarbageCollector\Tests\Processors;
 
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\GarbageCollector\Tests\CargoShip;
 use SilverStripe\ORM\DataList;
 use SilverStripe\GarbageCollector\Tests\Ship;
 use SilverStripe\GarbageCollector\Processors\DataListProcessor;
@@ -19,6 +20,7 @@ class DataListProcessorTest extends SapphireTest
      */
     protected static $extra_dataobjects = [
         Ship::class,
+        CargoShip::class,
     ];
 
     public function testProcessor()
@@ -31,8 +33,8 @@ class DataListProcessorTest extends SapphireTest
 
         // 2 records should have been removed
         $this->assertEquals($count, 2);
-        // 3 records should remain
-        $this->assertEquals(Ship::get()->count(), 3);
+        // 3 records (without subclasses) should remain
+        $this->assertEquals(Ship::get()->filter(['ClassName' => Ship::class])->count(), 3);
         $this->assertEquals(Ship::class, $processor->getName());
 
         $processor = new DataListProcessor($list, 'TestName');

--- a/tests/php/Processors/RawSQLProcessorTest.php
+++ b/tests/php/Processors/RawSQLProcessorTest.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\GarbageCollector\Tests\Processors;
 
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\GarbageCollector\Tests\CargoShip;
 use SilverStripe\ORM\DB;
 use SilverStripe\GarbageCollector\Tests\Ship;
 use SilverStripe\GarbageCollector\Models\RawSQL;
@@ -20,6 +21,7 @@ class RawSQLProcessorTest extends SapphireTest
      */
     protected static $extra_dataobjects = [
         Ship::class,
+        CargoShip::class,
     ];
 
     public function testProcessor()

--- a/tests/php/Processors/SQLExpressionProcessorTest.php
+++ b/tests/php/Processors/SQLExpressionProcessorTest.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\GarbageCollector\Tests\Processors;
 
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\GarbageCollector\Tests\CargoShip;
 use SilverStripe\GarbageCollector\Tests\Ship;
 use SilverStripe\ORM\Queries\SQLSelect;
 use SilverStripe\ORM\Queries\SQLExpression;
@@ -21,6 +22,7 @@ class SQLExpressionProcessorTest extends SapphireTest
      */
     protected static $extra_dataobjects = [
         Ship::class,
+        CargoShip::class,
     ];
 
     public function testProcess()
@@ -54,8 +56,8 @@ class SQLExpressionProcessorTest extends SapphireTest
         // 2 records should have been removed
         $this->assertEquals($count, 2);
 
-        // 3 records should remain (out of 4)
-        $this->assertEquals(Ship::get()->count(), 3);
+        // 3 records (without subclasses) should remain (out of 4)
+        $this->assertEquals(Ship::get()->filter(['ClassName' => Ship::class])->count(), 3);
 
         // Ensure base table is used for name
         $name = $processor->getName();


### PR DESCRIPTION
As raised, the recent minor enhancement changed the way how the list of tables was collected and caused duplication of base tables instead of using the class inheritance-based approach as it was before.

This addresses the issue and adds a test.

Fix for #16 