### PR TITLE
BUG: Collector job hydration fix.

### DIFF
--- a/src/Jobs/GarbageCollectorJob.php
+++ b/src/Jobs/GarbageCollectorJob.php
@@ -14,6 +14,10 @@ if (!class_exists(AbstractQueuedJob::class)) {
 
 
 /**
+ * @property CollectorInterface|null $collector
+ * @property int|null $batchSize
+ * @property array $remaining
+ * @property array $processors
  * @property array $versions
  * @property array $remainingVersions
  */
@@ -34,7 +38,7 @@ class GarbageCollectorJob extends AbstractQueuedJob
      *
      * @var string
      */
-    public function __construct(CollectorInterface $collector, $batchSize = 10)
+    public function __construct(?CollectorInterface $collector = null, $batchSize = 10)
     {
         parent::__construct();
 


### PR DESCRIPTION
# BUG: Collector job hydration fix

The collector job needs to have a constructor which is able to run without any params. This is because once job is stored in DB as a job descriptor it will be picked up by the queue runner which [will create a new instance of the job by calling the constructor without any params](https://github.com/symbiote/silverstripe-queuedjobs/blob/4/src/Services/QueuedJobService.php#L679). Any job data assignments in such constructor call are irrelevant as the job data is populated [right after that](https://github.com/symbiote/silverstripe-queuedjobs/blob/4/src/Services/QueuedJobService.php#L689). The main thing is that the code needs to be executable.

## Changes

* constructor is executable without any params
* docblock update

## Related issues

https://github.com/brettt89/silverstripe-garbage-collector/issues/28