### PR TITLE
Fix link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,4 @@ This project is made possible by the community surrounding it and especially the
 
 ### Libraries
 
-#### [silverstripe/framework] (https://github.com/silverstripe/silverstripe-framework)
+- [silverstripe/framework](https://github.com/silverstripe/silverstripe-framework)


### PR DESCRIPTION
Just fixing the broken link at the bottom of the readme from invalid markdown syntax.