### PR TITLE
Remove reliance on deprecated `next()` function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,7 @@
 .phpunit.result.cache
 /vendor/
 /assets/
+/_resources/
+/resources/
+/public/
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
     "require-dev": {
         "phpunit/phpunit": "^9.6.13",
         "squizlabs/php_codesniffer": "^3",
-        "tractorcow/silverstripe-fluent": "^5.0",
-        "silverstripe/versioned": "^1.8",
-        "symbiote/silverstripe-queuedjobs": "^4.7"
+        "tractorcow/silverstripe-fluent": "^5.0 | ^6 | ^7",
+        "silverstripe/versioned": "^1.8 | ^2",
+        "symbiote/silverstripe-queuedjobs": "^4.7 | ^5"
     },
     "suggest": {
         "symbiote/silverstripe-queuedjobs": "For usage of the GarbageCollectorJob within your application"


### PR DESCRIPTION
Fixes #39

The [MySQLStatement::next()](https://api.silverstripe.org/4/SilverStripe/ORM/Connect/MySQLStatement.html#method_next) method is deprecated in CMS5.

All the tests passed because they were only running in CMS4, ideally we need to replace the workflow to use the more standardised one which checks on a range of versions as per the composer config.

For the time-being, this fixes the issue by checking for the method availability before looping the results.